### PR TITLE
Updated the oracledb container image to a working image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
    oracledb:
-     image: wnameless/oracle-xe-11g
+     image: wnameless/oracle-xe-11g-r2
      restart: always
      ports:
       - "1521:1521"


### PR DESCRIPTION
The `wnameless/oracle-xe-11g` image is not longer working because it is banned by DockerHub.
The developer of `wnameless/oracle-xe-11g` released a new image to the hub, "wnameless/oracle-xe-11g-r2".
I've updated the `docker-compose.yml` to the new image.